### PR TITLE
Display system files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,11 +787,6 @@ impl FileDialog {
         .filter_map(|entry| {
           let info = FileInfo::new(entry.path());
           if !info.is_dir() {
-            // Do not show system files.
-            if !info.path.is_file() {
-              return None;
-            }
-
             // Filter.
             if !(self.show_files_filter)(&info.path) {
               return None;


### PR DESCRIPTION
Hello,
I wanted to use this library to open some files in /dev in linux, but as they were hidden by default it is not possible.
This PR allows those files to be displayed.
Thanks